### PR TITLE
Avoid modifying back history when setting result iframe src.

### DIFF
--- a/src/embed/main.js
+++ b/src/embed/main.js
@@ -41,7 +41,7 @@ export async function initSandbox() {
 
   Prism.highlightAll();
 
-  result.src = url;
+  result.contentWindow.location.replace(url);
 }
 
 initNavigation();


### PR DESCRIPTION
When a page embeds Indiepen in an iframe it affects the browser back stack in an undesirable way: one entry per embedded Indiepen iframe is added to the browser history, meaning to go back from a page you need to press the back button more than one time.

See for example https://stackoverflow.com/a/2257295 for reference about the proposed fix.